### PR TITLE
Allow ACF select2 Fields to Display SVG Icons Properly

### DIFF
--- a/assets/js/admin/editor.src.js
+++ b/assets/js/admin/editor.src.js
@@ -1,0 +1,22 @@
+(function ($) {
+    if ('object' !== typeof acf) {
+        return;
+    }
+    // Allow svgs in icon select fields. ACF < 2.6.8
+    acf.add_filter('select2_args', function (args, $select, settings, field, instance) {
+        // Taken from `acf-input.js`, just removed escaping from `$selection.html(acf.strEscape(selection.text));`.
+        args.templateSelection = function (selection) {
+            var $selection = $('<span class="acf-selection"></span>');
+            $selection.html(selection.text);
+            $selection.data('element', selection.element);
+            return $selection;
+        };
+
+        return args;
+    });
+
+    // Allow svgs in icon select fields. ACF >= 2.6.8.
+    acf.add_filter('select2_escape_markup', function (escaped_value, original_value, $select, settings, field, instance) {
+        return original_value;
+    });
+})(jQuery);

--- a/functions/class-rh-scripts-and-styles.php
+++ b/functions/class-rh-scripts-and-styles.php
@@ -23,6 +23,7 @@ class RH_Scripts_And_Styles {
 	public function setup_actions() {
 		add_action( 'init', array( $this, 'action_init' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'action_wp_enqueue_scripts' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'action_enqueue_block_editor_assets' ) );
 		add_action( 'wp_default_scripts', array( $this, 'action_wp_default_scripts' ) );
 
 		// We want styles to come after scripts in the <head>
@@ -60,6 +61,14 @@ class RH_Scripts_And_Styles {
 			array(),
 			null,
 			'all'
+		);
+
+		wp_register_script(
+			'rh-editor',
+			get_template_directory_uri() . '/assets/js/admin/editor.js',
+			$deps      = array( 'jquery' ),
+			$ver       = null,
+			$in_footer = true
 		);
 
 		// Don't load the WP Embed script. See https://wordpress.stackexchange.com/a/285907/2744
@@ -111,6 +120,13 @@ class RH_Scripts_And_Styles {
 		wp_dequeue_script( 'automatic-upload-images' );
 
 		wp_enqueue_script( 'instant.page' );
+	}
+
+	/**
+	 * Enqueue assets when the block editor is loaded
+	 */
+	public function action_enqueue_block_editor_assets() {
+		wp_enqueue_script( 'rh-editor' );
 	}
 
 	/**


### PR DESCRIPTION
In ACF 6.2.8 they started escaping HTML markup in select2 fields. See https://www.advancedcustomfields.com/blog/acf-6-2-8-rc1/

Thanks to https://github.com/maithemewp/mai-engine/blob/7d533ce0f1ae5526cce36210214e70c09a8470aa/assets/js/editor.js#L34-L60 we can undo this escaping on select2 fields in ACF and display our SVG icons properly again.

Fixes #4 

Before:
![Screenshot 2024-04-26 at 11 29 48 PM](https://github.com/kingkool68/wordpress-rh-starter-theme/assets/867430/b87239a9-d25b-4a5d-9db2-1bdabba6670d)

After:
![Screenshot 2024-04-26 at 11 29 19 PM](https://github.com/kingkool68/wordpress-rh-starter-theme/assets/867430/02d62793-ca1f-499b-876a-394e47facad6)
